### PR TITLE
update compile.sh to include read_parameters2.c

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,1 +1,1 @@
-gcc -o spectral.x main.c cosmic_rays.c runge_kutta.c synchrotron.c read_parameters.c jet.c -lm
+gcc -o spectral.x main.c cosmic_rays.c runge_kutta.c synchrotron.c read_parameters.c jet.c read_parameters2.c -lm


### PR DESCRIPTION
read_parameters2.c was not included in the gcc command in compile.sh. This pull request fixes it. 